### PR TITLE
feat [flake]: get events from server, show them in the ui

### DIFF
--- a/src/graphs/d3/heatmap/canvasHeatmap.js
+++ b/src/graphs/d3/heatmap/canvasHeatmap.js
@@ -78,15 +78,17 @@ class CanvasHeatmap {
       { color: "#ff0000", rgba: [255, 0, 0, 255], point: 1 },
     ],
   };
-  constructor(div, data, options = {}) {
+  constructor(div, data, events, options = {}) {
     this._div = div;
     this._setData(data);
+    this._setEvents(events);
     this._setOptions(options);
     this._processContour();
     this._onAdd();
   }
-  update(data, options) {
+  update(data, events, options) {
     this._setData(data);
+    this._setEvents(events);
     this._setOptions(options);
     this._processContour();
     this._onAdd();
@@ -96,8 +98,9 @@ class CanvasHeatmap {
     this._processContour();
     this._onAdd();
   }
-  updateData(data) {
+  updateData(data, events) {
     this._setData(data);
+    this._setEvents(events);
     this._processContour();
     this._plot();
   }
@@ -138,6 +141,9 @@ class CanvasHeatmap {
     this._yTime = data[0].y[0] instanceof Date;
     this._data = data;
     this._dataExtents();
+  }
+  _setEvents(events) {
+    this._events = events;
   }
   _processContour() {
     if (this.options.contour) {
@@ -778,46 +784,113 @@ class CanvasHeatmap {
         var xValue = this._xAxis.ax.invert(hoverX);
         var yValue = this._yAxis.ax.invert(hoverY);
 
+        var html = "";
+
         var idx = Math.max(
           getFileIndex(this._xFileDomain, xValue),
           getFileIndex(this._yFileDomain, yValue)
         );
         var process = this._data[idx];
 
-        var xi = closest(xValue, process.x);
-        var yi = closest(yValue, process.y);
+        if (process === undefined) {
+          // no value but we may still find have some events information to display
+          var xval, yval;
+          var xu = "";
+          var yu = "";
+          var time;
+          var depth;
 
-        var xval, yval;
-        var xu = "";
-        var yu = "";
-        var zu = "";
-        var zval = process.z[yi][xi];
+          if (this._xTime) {
+            time = xValue;
+            xval = formatDate(time, lang);
+          } else {
+            xval = formatNumber(xValue);
+            if (typeof this.options.xUnit === "string") xu = this.options.xUnit;
+            if (this.options.xLabel === "Depth") {
+              xval = formatNumber(xValue, 1);
+              depth = xval;
+            }
+          }
+          if (this._yTime) {
+            time = yValue;
+            yval = formatDate(time, lang);
+          } else {
+            yval = formatNumber(yValue);
+            if (typeof this.options.yUnit === "string") yu = this.options.yUnit;
+            if (this.options.yLabel === "Depth") {
+              yval = formatNumber(yValue, 1);
+              depth = yval;
+            }
+          }
 
-        if (this._xTime) {
-          xval = formatDate(process.x[xi], lang);
+          if (time) {
+            html = this._makeActiveEventsHTML(time, depth);
+            if (html && html !== "") {
+              html = `
+                <table>
+                  <tbody>
+                    <tr><td>x:</td><td>${xval} ${xu}</td></tr>
+                    <tr><td>y:</td><td>${yval} ${yu}</td></tr>
+                  </tbody>
+                </table>
+                ${html}`;
+            }
+          }
         } else {
-          xval = formatNumber(process.x[xi]);
-          if (typeof this.options.xUnit === "string") xu = this.options.xUnit;
+          // display values and associated events if any
+          var xi = closest(xValue, process.x);
+          var yi = closest(yValue, process.y);
+
+          var xval, yval;
+          var xu = "";
+          var yu = "";
+          var zu = "";
+          var zval = process.z[yi][xi];
+          var time;
+          var depth;
+
+          if (this._xTime) {
+            time = process.x[xi];
+            xval = formatDate(time, lang);
+          } else {
+            xval = formatNumber(process.x[xi]);
+            if (typeof this.options.xUnit === "string") xu = this.options.xUnit;
+            if (this.options.xLabel === "Depth") {
+              depth = process.x[xi];
+            }
+          }
+
+          if (this._yTime) {
+            time = process.y[yi];
+            yval = formatDate(time, lang);
+          } else {
+            yval = formatNumber(process.y[yi]);
+            if (typeof this.options.yUnit === "string") yu = this.options.yUnit;
+            if (this.options.yLabel === "Depth") {
+              depth = process.y[yi];
+            }
+          }
+
+          if (typeof this.options.zUnit === "string") zu = this.options.zUnit;
+
+          html =`
+            <table><tbody>
+              <tr><td>x:</td><td>${xval} ${xu}</td></tr>
+              <tr><td>y:</td><td>${yval} ${yu}</td></tr>
+              <tr><td>z:</td><td>${formatNumber(zval, this.options.decimalPlaces)} ${zu}</td></tr>
+            </tbody></table>
+            ${this._makeActiveEventsHTML(time, depth)}`;
         }
 
-        if (this._yTime) {
-          yval = formatDate(process.y[yi], lang);
-        } else {
-          yval = formatNumber(process.y[yi]);
-          if (typeof this.options.yUnit === "string") yu = this.options.yUnit;
+        if (html === "") {
+          // nothing to be displayed
+          vpi.style("opacity", 0);
+          tooltip.style("opacity", 0);
+          select("#zpointer_" + this._div).style("opacity", 0);
+          if (this.options.hover)
+            this.options.hover({ mousex: false, mousey: false });
+          return;
         }
-
-        if (typeof this.options.zUnit === "string") zu = this.options.zUnit;
-
-        var html =
-          "<table><tbody>" +
-          `<tr><td>x:</td><td>${xval} ${xu}</td></tr>` +
-          `<tr><td>y:</td><td>${yval} ${yu}</td></tr>` +
-          `<tr><td>z:</td><td>${formatNumber(
-            zval,
-            this.options.decimalPlaces
-          )} ${zu}</td></tr>` +
-          "</tbody></table>";
 
         if (hoverX > this._width / 2) {
           tooltip
@@ -825,7 +898,7 @@ class CanvasHeatmap {
             .style(
               "right",
               this._width -
-                this._xAxis.ax(process.x[xi]) -
+                (process ? this._xAxis.ax(process.x[xi]) : hoverX) -
                 this.options.marginLeft +
                 10 +
                 "px"
@@ -833,7 +906,7 @@ class CanvasHeatmap {
             .style("left", "auto")
             .style(
               "top",
-              this._yAxis.ax(process.y[yi]) + this.options.marginTop - 20 + "px"
+              (process ? this._yAxis.ax(process.y[yi]) : hoverY) + this.options.marginTop - 20 + "px"
             )
             .attr("class", "tooltip tooltip-right")
             .style("opacity", 1);
@@ -842,7 +915,7 @@ class CanvasHeatmap {
             .html(html)
             .style(
               "left",
-              this._xAxis.ax(process.x[xi]) +
+              (process ? this._xAxis.ax(process.x[xi]) : hoverX) +
                 this.options.marginLeft +
                 10 +
                 "px"
@@ -850,7 +923,7 @@ class CanvasHeatmap {
             .style("right", "auto")
             .style(
               "top",
-              this._yAxis.ax(process.y[yi]) + this.options.marginTop - 20 + "px"
+              (process ? this._yAxis.ax(process.y[yi]) : hoverY) + this.options.marginTop - 20 + "px"
             )
             .attr("class", "tooltip tooltip-left")
             .style("opacity", 1);
@@ -938,6 +1011,75 @@ class CanvasHeatmap {
     });
     this._tooltip = tooltip;
     this._vpi = vpi;
+  }
+  _makeActiveEventsHTML(time, depth) {
+    var activeEvents = [];
+    if (time) {
+      this._events.forEach((evt) => {
+        if (evt.interval[0] <= time && evt.interval[1] >= time) {
+          if (depth !== undefined) {
+            // filter by depth in list or range
+            evt.events.forEach((e) => {
+              // all depths apply
+              if (e.depth === undefined || e.depth.trim() === "" || e.depth.trim() === "All") {
+                activeEvents.push(e);
+                return;
+              }
+
+              // depth range
+              var depthRange = e.depth.split("-").map((d) => d.trim());
+              if (depthRange.length > 1) {
+                try {
+                  var start = parseFloat(depthRange[0]);
+                  var end = parseFloat(depthRange[1]);
+                  if (depth >= start && depth <= end) {
+                    activeEvents.push(e);
+                  }
+                } catch (e) {
+                  console.error("Error parsing depth range:", e);
+                }
+                return;
+              }
+
+              // depth list
+              var depthList = e.depth.split(",").map((d) => d.trim());
+              for (var i = 0; i < depthList.length; i++) {
+                try {
+                  var reported = parseFloat(depthList[i]);
+                  var span = 0.5;
+                  if (depth >= reported - span && depth <= reported + span) {
+                    activeEvents.push(e);
+                    return;
+                  }
+                } catch (e) {
+                  console.error("Error parsing depth list:", e);
+                }
+              }
+            });
+          } else {
+            // no depth filter
+            activeEvents.push(...evt.events);
+          }
+          
+        }
+      });
+    }
+    if (activeEvents.length > 0) {
+      var eventHTML = `
+        <div class="tooltip-events">
+          <div class="tooltip-events-header">Events:</div>
+          <table>
+            <thead>
+              <tr><th>Parameters</th><th>Depths</th><th>Comments</th></tr>
+            </thead>
+            <tbody>`;
+      activeEvents.forEach((evt) => {
+        eventHTML += `<tr><td>${evt.parameter}</td><td style="max-width: 100px">${evt.depth ? evt.depth.split(',').join(', ') : ''}</td><td>${evt.comments}</td></tr>`;
+      });
+      eventHTML += `</tbody></table></div>`;
+      return eventHTML;
+    }
+    return "";
   }
   _addZoom() {
     this._zoomEnabled = true;

--- a/src/graphs/d3/heatmap/heatmap.jsx
+++ b/src/graphs/d3/heatmap/heatmap.jsx
@@ -286,10 +286,10 @@ class D3HeatMap extends Component {
     if ("display" in this.props) {
       this.setState({ display: this.props.display });
     }
-    const { data } = this.props;
+    const { data, events } = this.props;
     const { graphid } = this.state;
     const options = this.prepareOptions();
-    this.heatmap = new CanvasHeatmap("vis" + graphid, data, options);
+    this.heatmap = new CanvasHeatmap("vis" + graphid, data, events, options);
     let firstRun = true;
     const myObserver = new ResizeObserver((entries) => {
       if (firstRun) {
@@ -305,15 +305,16 @@ class D3HeatMap extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     var { display, fontSize, fullscreen, xgraph, ygraph } = this.state;
+    const { data, events } = this.props;
     var compareProps = !isEqual(prevProps, this.props);
     if (
-      !isEqual(prevProps.data.z, this.props.data.z) &&
+      !isEqual(prevProps.data.z, data.z) &&
       isEqual(
         { ...prevProps, data: { ...prevProps.data, z: undefined } },
-        { ...this.props, data: { ...this.props.data, z: undefined } }
+        { ...this.props, data: { ...data, z: undefined } }
       )
     ) {
-      this.heatmap.updateData(this.props.data);
+      this.heatmap.updateData(data, events);
     } else if (
       compareProps ||
       display !== prevState.display ||
@@ -323,7 +324,7 @@ class D3HeatMap extends Component {
       ygraph !== prevState.ygraph
     ) {
       const options = this.prepareOptions();
-      this.heatmap.update(this.props.data, options);
+      this.heatmap.update(data, events, options);
     }
   }
 
@@ -351,6 +352,7 @@ class D3HeatMap extends Component {
       yReverse,
       maxvalue,
       minvalue,
+      events,
     } = this.props;
 
     const TimeLabels = ["Time", "time", "datetime", "Datetime", "Date", "date"];
@@ -405,6 +407,7 @@ class D3HeatMap extends Component {
                     plotdots={false}
                     xscale={TimeLabels.includes(zlabel) ? "Time" : ""}
                     yscale={TimeLabels.includes(ylabel) ? "Time" : ""}
+                    events={events}
                   />
                 )}
               </div>
@@ -428,6 +431,7 @@ class D3HeatMap extends Component {
                   xscale={TimeLabels.includes(xlabel) ? "Time" : ""}
                   yscale={TimeLabels.includes(zlabel) ? "Time" : ""}
                   simple={true}
+                  events={events}
                 />
               )}
             </div>

--- a/src/graphs/d3/linegraph/linegraph.jsx
+++ b/src/graphs/d3/linegraph/linegraph.jsx
@@ -232,6 +232,7 @@ class D3LineGraph extends Component {
       grid,
       language,
       curve,
+      events,
     } = this.props;
     var { graphid, fontSize } = this.state;
 
@@ -278,7 +279,7 @@ class D3LineGraph extends Component {
     if (ymax) options["yMax"] = ymax;
     if (ymin) options["yMin"] = ymin;
     if (curve) options["curve"] = curve;
-    plotlinegraph("vis" + graphid, data, options);
+    plotlinegraph("vis" + graphid, data, events, options);
   };
 
   componentDidMount() {

--- a/src/graphs/d3/linegraph/plotlinegraph.js
+++ b/src/graphs/d3/linegraph/plotlinegraph.js
@@ -43,7 +43,7 @@ import {
   verifyFunction,
 } from "./verify";
 
-const plotlinegraph = (div, data, options = {}) => {
+const plotlinegraph = (div, data, events, options = {}) => {
   for (var r of ["svg", "canvas", "tooltip", "background"]) {
     try {
       select(`#${r}_${div}`).remove();
@@ -51,7 +51,6 @@ const plotlinegraph = (div, data, options = {}) => {
       console.error(e);
     }
   }
-
   verifyDiv(div);
 
   data = processData(data);
@@ -82,16 +81,15 @@ const plotlinegraph = (div, data, options = {}) => {
 
   var plot = addPlottingArea(div, svg, options);
   if (options.legend) addLegend(svg, div, data, options);
-  if (options.lines) plotLines(div, plot, data, xAxis, yAxis, options.curve);
-  if (options.scatter) plotScatter(context, data, xAxis, yAxis, options);
+  updatePlots(div, plot, svg, context, data, events, xAxis, yAxis, options);
   var zmbox = null;
   var zm = null;
   if (options.zoom) {
-    var { zoombox, zoom } = addZoom(plot, context, data, div, xAxis, yAxis, options);
+    var { zoombox, zoom } = addZoom(svg, plot, context, data, events, div, xAxis, yAxis, options);
     zmbox = zoombox;
     zm = zoom;
   }
-  if (options.tooltip) addTooltip(data, div, xAxis, yAxis, options);
+  if (options.tooltip) addTooltip(data, events, div, xAxis, yAxis, options);
   if (options.select) addBrush(svg, xAxis, yAxis, zmbox, zm, options);
 };
 
@@ -724,7 +722,7 @@ const addBorder = (svg, options) => {
     .attr("fill", "none");
 };
 
-const addTooltip = (data, div, xAxis, yAxis, options) => {
+const addTooltip = (data, events, div, xAxis, yAxis, options) => {
   var max_distance = 20;
   var zoombox = select(`#interact_${div}`);
   var tooltip = select("#" + div)
@@ -743,15 +741,45 @@ const addTooltip = (data, div, xAxis, yAxis, options) => {
       var hoverX = event.clientX - rect.left;
       var hoverY = event.clientY - rect.top;
 
-      var { idx, idy, distance } = closest(data, hoverX, hoverY, xAxis, yAxis);
+      function makeActiveEventsHTML(time) {
+        var activeEvents = [];
+        if (time) {
+          events.forEach((evt) => {
+            if (evt.interval[0] <= time && evt.interval[1] >= time) {
+              activeEvents.push(...evt.events);
+            }
+          });
+        }
+        if (activeEvents.length > 0) {
+          var eventHTML = `
+            <div class="tooltip-events">
+              <div class="tooltip-events-header">Events:</div>
+              <table>
+                <thead>
+                  <tr><th>Parameters</th><th>Depths</th><th>Comments</th></tr>
+                </thead>
+                <tbody>`;
+          activeEvents.forEach((evt) => {
+            eventHTML += `<tr><td>${evt.parameter}</td><td style="max-width: 100px">${evt.depth ? evt.depth.split(',').join(', ') : ''}</td><td>${evt.comments}</td></tr>`;
+          });
+          eventHTML += `</tbody></table></div>`;
+          return eventHTML;
+        }
+        return "";
+      }
 
+      var { idx, idy, distance } = closest(data, hoverX, hoverY, xAxis, yAxis);
+      var html;
+      var posx = hoverX;
+      var posy = hoverY;
       if (distance < max_distance) {
         var xval, yval;
-        var xu = "",
-          yu = "";
+        var xu = "", yu = "";
+        var time;
 
         if (options.xTime) {
-          xval = formatDate(data[idx].x[idy], lang, options.noYear);
+          time = data[idx].x[idy];
+          xval = formatDate(time, lang, options.noYear);
         } else {
           xval = formatNumber(data[idx].x[idy]);
           if (typeof options.xUnit === "string") {
@@ -760,7 +788,8 @@ const addTooltip = (data, div, xAxis, yAxis, options) => {
         }
 
         if (options.yTime) {
-          yval = formatDate(data[idx].y[idy], lang, options.noYear);
+          time = data[idx].y[idy];
+          yval = formatDate(time, lang, options.noYear);   
         } else {
           yval = formatNumber(data[idx].y[idy]);
           if (typeof options.yUnit === "string") {
@@ -768,59 +797,91 @@ const addTooltip = (data, div, xAxis, yAxis, options) => {
           }
         }
 
-        var html = `
-                <table style="color:${data[idx].lineColor};">
-                    <tbody>
-                        <tr><td>x:</td><td>${xval} ${xu}</td></tr>
-                        <tr><td>y:</td><td>${yval} ${yu}</td></tr>
-                    </tbody>
-                </table>`;
+        html = `
+          <table style="color:${data[idx].lineColor};">
+              <tbody>
+                  <tr><td>x:</td><td>${xval} ${xu}</td></tr>
+                  <tr><td>y:</td><td>${yval} ${yu}</td></tr>
+              </tbody>
+          </table>
+          ${makeActiveEventsHTML(time)}`;
 
         if ("tooltip" in data[idx]) {
           html = data[idx].tooltip[idy] + html;
         }
+        if (hoverX > options.width / 2) {
+          posx = options.width -
+            options.marginLeft -
+            xAxis[data[idx].xaxis].ax(data[idx].x[idy]) +
+            10;
+          posy = yAxis[data[idx].yaxis].ax(data[idx].y[idy]) +
+            options.marginTop -
+            options.fontSize -
+            6;
+        } else {
+          posx = xAxis[data[idx].xaxis].ax(data[idx].x[idy]) +
+            options.marginLeft +
+            10;
+          posy = yAxis[data[idx].yaxis].ax(data[idx].y[idy]) +
+            options.marginTop -
+            options.fontSize -
+            6;
+        }
+      } else {
+        // show active events if any at the mouse position
+        var time;
 
+        if (options.xTime) {
+          time = xAxis[data[idx].xaxis].ref.invert(hoverX);
+        }
+        else if (options.yTime) {
+          time = yAxis[data[idx].yaxis].ref.invert(hoverY);
+        }
+        html = makeActiveEventsHTML(time);
+        if (html && html !== "") {
+          html = `
+          <table style="color:${data[idx].lineColor};">
+              <tbody>
+                  <tr><td>${options.xTime ? 'x' : 'y'}:</td><td>${formatDate(time, lang, options.noYear)}</td></tr>
+              </tbody>
+          </table>
+          ${html}`;
+        }
+        if (hoverX > options.width / 2) {
+          posx = options.width -
+            options.marginLeft -
+            hoverX +
+            10;
+          posy = hoverY +
+            options.marginTop -
+            options.fontSize -
+            6;
+        } else {
+          posx = hoverX +
+            options.marginLeft +
+            10;
+          posy = hoverY +
+            options.marginTop -
+            options.fontSize -
+            6;
+        }
+      }
+
+      if (html && html !== "") {
         if (hoverX > options.width / 2) {
           tooltip
             .html(html)
-            .style(
-              "right",
-              options.width -
-                options.marginLeft -
-                xAxis[data[idx].xaxis].ax(data[idx].x[idy]) +
-                10 +
-                "px"
-            )
+            .style("right", posx + "px")
             .style("left", "auto")
-            .style(
-              "top",
-              yAxis[data[idx].yaxis].ax(data[idx].y[idy]) +
-                options.marginTop -
-                options.fontSize -
-                6 +
-                "px"
-            )
+            .style("top", posy + "px")
             .attr("class", "tooltip tooltip-right")
             .style("opacity", 1);
         } else {
           tooltip
             .html(html)
-            .style(
-              "left",
-              xAxis[data[idx].xaxis].ax(data[idx].x[idy]) +
-                options.marginLeft +
-                10 +
-                "px"
-            )
+            .style("left", posx + "px")
             .style("right", "auto")
-            .style(
-              "top",
-              yAxis[data[idx].yaxis].ax(data[idx].y[idy]) +
-                options.marginTop -
-                options.fontSize -
-                6 +
-                "px"
-            )
+            .style("top", posy + "px")
             .attr("class", "tooltip tooltip-left")
             .style("opacity", 1);
         }
@@ -903,7 +964,7 @@ const downloadGraph = (div, options) => {
   title.style("opacity", "0");
 };
 
-const plotLines = (div, g, data, xAxis, yAxis, curve) => {
+const plotLines = (div, g, data, xAxis, yAxis, options) => {
   g.selectAll("path").remove();
   for (let j = 0; j < data.length; j++) {
     plotConfidenceInterval(
@@ -914,62 +975,34 @@ const plotLines = (div, g, data, xAxis, yAxis, curve) => {
     );
   }
   for (let j = 0; j < data.length; j++) {
-    if (curve) {
-      g.append("path")
-        .datum(data[j].x)
-        .attr("id", `line_${j}_${div}`)
-        .attr("fill", "none")
-        .attr("stroke", data[j].lineColor)
-        .attr("stroke-width", data[j].lineWeight)
-        .attr(
-          "d",
-          line()
-            .x(function (d) {
-              return xAxis[data[j].xaxis].ax(d);
-            })
-            .y(function (d, i) {
-              return yAxis[data[j].yaxis].ax(data[j].y[i]);
-            })
-            .curve(curveNatural)
-            .defined(function (d, i) {
-              if (
-                isNumeric(xAxis[data[j].xaxis].ax(d)) &&
-                isNumeric(yAxis[data[j].yaxis].ax(data[j].y[i]))
-              ) {
-                return true;
-              } else {
-                return false;
-              }
-            })
-        );
-    } else {
-      g.append("path")
-        .datum(data[j].x)
-        .attr("id", `line_${j}_${div}`)
-        .attr("fill", "none")
-        .attr("stroke", data[j].lineColor)
-        .attr("stroke-width", data[j].lineWeight)
-        .attr(
-          "d",
-          line()
-            .x(function (d) {
-              return xAxis[data[j].xaxis].ax(d);
-            })
-            .y(function (d, i) {
-              return yAxis[data[j].yaxis].ax(data[j].y[i]);
-            })
-            .defined(function (d, i) {
-              if (
-                isNumeric(xAxis[data[j].xaxis].ax(d)) &&
-                isNumeric(yAxis[data[j].yaxis].ax(data[j].y[i]))
-              ) {
-                return true;
-              } else {
-                return false;
-              }
-            })
-        );
+    // actual data
+    var lineGenerator = line()
+      .x(function (d) {
+        return xAxis[data[j].xaxis].ax(d);
+      })
+      .y(function (d, i) {
+        return yAxis[data[j].yaxis].ax(data[j].y[i]);
+      });
+    if (options.curve) {
+      lineGenerator = lineGenerator.curve(curveNatural);
     }
+    lineGenerator = lineGenerator.defined(function (d, i) {
+      if (
+        isNumeric(xAxis[data[j].xaxis].ax(d)) &&
+        isNumeric(yAxis[data[j].yaxis].ax(data[j].y[i]))
+      ) {
+        return true;
+      } else {
+        return false;
+      }
+    });
+    g.append("path")
+      .datum(data[j].x)
+      .attr("id", `line_${j}_${div}`)
+      .attr("fill", "none")
+      .attr("stroke", data[j].lineColor)
+      .attr("stroke-width", data[j].lineWeight)
+      .attr("d", lineGenerator);
   }
 };
 
@@ -1045,7 +1078,6 @@ const plotConfidenceInterval = (g, data, xAxis, yAxis) => {
 };
 
 const plotScatter = (context, data, xAxis, yAxis, options) => {
-  context.clearRect(0, 0, options.canvasWidth, options.canvasHeight);
   for (var i = 0; i < data.length; i++) {
     if ("symbol" in data[i] && data[i].symbol === "x") {
       for (let j = 0; j < data[i].x.length; j++) {
@@ -1128,6 +1160,20 @@ const addInteractionBoxes = (svg, div, options) => {
   }
 };
 
+const plotEvents = (context, events, xAxis, options) => {
+  events.forEach(event => {
+    const x = xAxis.x.ax(event.interval[0]);
+    const w = xAxis.x.ax(event.interval[1]) - x;
+  
+    if (w > 0) {
+      context.fillStyle = "rgba(128, 128, 128, 0.1)";
+      context.fillRect(x, 0, w, options.canvasHeight);
+    }
+    
+  });
+  
+};
+
 const editTicks = (xAxis, yAxis) => {
   xAxis.x.g
     .selectAll(".tick line")
@@ -1139,7 +1185,7 @@ const editTicks = (xAxis, yAxis) => {
     .attr("stroke-dasharray", "4");
 };
 
-const addZoom = (g, context, data, div, xAxis, yAxis, options) => {
+const addZoom = (svg, g, context, data, events, div, xAxis, yAxis, options) => {
   var zoom = d3zoom()
     .extent([
       [0, 0],
@@ -1204,8 +1250,7 @@ const addZoom = (g, context, data, div, xAxis, yAxis, options) => {
         yAxis.y2.axis.scale(yAxis.y2.ax);
         yAxis.y2.g.call(yAxis.y2.axis);
       }
-      if (options.lines) plotLines(div, g, data, xAxis, yAxis, options.curve);
-      if (options.scatter) plotScatter(context, data, xAxis, yAxis, options);
+      updatePlots(div, g, svg, context, data, events, xAxis, yAxis, options);
       xAxis.x.ref = xAxis.x.ax;
       if (options.dualaxis === "x2") xAxis.x2.ref = xAxis.x2.ax;
       yAxis.y.ref = yAxis.y.ax;
@@ -1221,8 +1266,7 @@ const addZoom = (g, context, data, div, xAxis, yAxis, options) => {
       xAxis.x.ax = t.rescaleX(xAxis.x.ref);
       xAxis.x.axis.scale(xAxis.x.ax);
       xAxis.x.g.call(xAxis.x.axis);
-      if (options.lines) plotLines(div, g, data, xAxis, yAxis, options.curve);
-      if (options.scatter) plotScatter(context, data, xAxis, yAxis, options);
+      updatePlots(div, g, svg, context, data, events, xAxis, yAxis, options);
       xAxis.x.ref = xAxis.x.ax;
       zoomboxx.call(zoom.transform, zoomIdentity);
       if (options.grid) editTicks(xAxis, yAxis);
@@ -1235,8 +1279,7 @@ const addZoom = (g, context, data, div, xAxis, yAxis, options) => {
       xAxis.x2.ax = t.rescaleX(xAxis.x2.ref);
       xAxis.x2.axis.scale(xAxis.x2.ax);
       xAxis.x2.g.call(xAxis.x2.axis);
-      if (options.lines) plotLines(div, g, data, xAxis, yAxis, options.curve);
-      if (options.scatter) plotScatter(context, data, xAxis, yAxis, options);
+      updatePlots(div, g, svg, context, data, events, xAxis, yAxis, options);
       xAxis.x2.ref = xAxis.x2.ax;
       zoomboxx2.call(zoom.transform, zoomIdentity);
       if (options.grid) editTicks(xAxis, yAxis);
@@ -1249,8 +1292,7 @@ const addZoom = (g, context, data, div, xAxis, yAxis, options) => {
       yAxis.y.ax = t.rescaleY(yAxis.y.ref);
       yAxis.y.axis.scale(yAxis.y.ax);
       yAxis.y.g.call(yAxis.y.axis);
-      if (options.lines) plotLines(div, g, data, xAxis, yAxis, options.curve);
-      if (options.scatter) plotScatter(context, data, xAxis, yAxis, options);
+      updatePlots(div, g, svg, context, data, events, xAxis, yAxis, options);
       yAxis.y.ref = yAxis.y.ax;
       zoomboxy.call(zoom.transform, zoomIdentity);
       if (options.grid) editTicks(xAxis, yAxis);
@@ -1263,8 +1305,7 @@ const addZoom = (g, context, data, div, xAxis, yAxis, options) => {
       yAxis.y2.ax = t.rescaleY(yAxis.y2.ref);
       yAxis.y2.axis.scale(yAxis.y2.ax);
       yAxis.y2.g.call(yAxis.y2.axis);
-      if (options.lines) plotLines(div, g, data, xAxis, yAxis, options.curve);
-      if (options.scatter) plotScatter(context, data, xAxis, yAxis, options);
+      updatePlots(div, g, svg, context, data, events, xAxis, yAxis, options);
       yAxis.y2.ref = yAxis.y2.ax;
       zoomboxy2.call(zoom.transform, zoomIdentity);
       if (options.grid) editTicks(xAxis, yAxis);
@@ -1292,8 +1333,7 @@ const addZoom = (g, context, data, div, xAxis, yAxis, options) => {
       yAxis.y2.axis.scale(yAxis.y2.base);
       yAxis.y2.g.call(yAxis.y2.axis);
     }
-    if (options.lines) plotLines(div, g, data, xAxis, yAxis, options.curve);
-    if (options.scatter) plotScatter(context, data, xAxis, yAxis, options);
+    updatePlots(div, g, svg, context, data, events, xAxis, yAxis, options);
     if (options.grid) editTicks(xAxis, yAxis);
   });
   zoomboxx.on("dblclick.zoom", null);
@@ -1301,6 +1341,16 @@ const addZoom = (g, context, data, div, xAxis, yAxis, options) => {
   if (options.dualaxis === "x2") zoomboxx2.on("dblclick.zoom", null);
   if (options.dualaxis === "y2") zoomboxy2.on("dblclick.zoom", null);
   return { zoombox, zoom };
+};
+
+const updatePlots = (div, g, svg, context, data, events, xAxis, yAxis, options) => {
+  context.clearRect(0, 0, options.canvasWidth, options.canvasHeight);
+  if (events.length > 0) {
+    //console.debug("events", events);
+    plotEvents(context, events, xAxis, options);
+  }
+  if (options.lines) plotLines(div, g, data, xAxis, yAxis, options);
+  if (options.scatter) plotScatter(context, data, xAxis, yAxis, options);
 };
 
 const addBrush = (svg, xAxis, yAxis, zoombox, zoom, options) => {

--- a/src/pages/datadetail/css/datadetail.css
+++ b/src/pages/datadetail/css/datadetail.css
@@ -1106,3 +1106,21 @@ h2 {
   color: #38bec9;
   border-color: #38bec9;
 }
+
+.tooltip-events-header {
+  padding-top: 5px;
+}
+.tooltip-events thead {
+  background-color: #f2f5f7;
+  font-weight: bold;
+}
+.tooltip-events table, .tooltip-events th, .tooltip-events td {
+  border: 1px solid #eee;
+  border-collapse: collapse;
+}
+.tooltip-events th {
+  text-align: left;
+}
+.tooltip-events th, .tooltip-events td {
+  padding: 5px;
+}

--- a/src/pages/datadetail/datadetail.jsx
+++ b/src/pages/datadetail/datadetail.jsx
@@ -44,6 +44,7 @@ class DataDetail extends Component {
     iframe: false,
     search: false,
     maintenance: false,
+    events: false,
   };
 
   // Download data
@@ -627,6 +628,7 @@ class DataDetail extends Component {
       // Get Pipeline Data
       var renku = false;
       var scripts = [];
+      var events = [];
       if (dataset.renku === 0) {
         try {
           ({ data: renku } = await axios.post(
@@ -650,6 +652,15 @@ class DataDetail extends Component {
       } catch (e) {
         console.error("Failed to collect scripts.");
       }
+      try {
+        ({ data: events } = await axios({
+          method: "get",
+          url: apiUrl + "/pipeline/events/" + dataset_id,
+          timeout: 2000,
+        }));
+      } catch (e) {
+        console.error("Failed to collect events.");
+      }
 
       this.setState({
         renku,
@@ -671,6 +682,7 @@ class DataDetail extends Component {
         search,
         lang,
         maintenance,
+        events,
       });
     } else if (mapplotfunction === "meteolakes") {
       this.setState({
@@ -774,6 +786,7 @@ class DataDetail extends Component {
       lang,
       dropdown,
       maintenance,
+      events,
       file_tree,
       prefix,
       repo,
@@ -842,6 +855,7 @@ class DataDetail extends Component {
                 iframe={iframe}
                 search={search}
                 maintenance={maintenance}
+                events={events}
               />
             </div>
           </React.Fragment>
@@ -949,6 +963,7 @@ class DataDetail extends Component {
                 getLabel={this.getLabel}
                 scripts={scripts}
                 maintenance={maintenance}
+                events={events}
               />
             </div>
           </React.Fragment>

--- a/src/pages/datadetail/inner/information.jsx
+++ b/src/pages/datadetail/inner/information.jsx
@@ -44,7 +44,7 @@ class Information extends Component {
   };
 
   render() {
-    const { dataset, getLabel, scripts, maintenance } = this.props;
+    const { dataset, getLabel, scripts, maintenance, events } = this.props;
     var script = scripts.filter((s) => s.name.includes(".md"));
     var dict = {};
     for (let i = 0; i < maintenance.length; i++) {
@@ -68,6 +68,7 @@ class Information extends Component {
                 ? ` (${maintenance[i].detail})`
                 : ""),
           ],
+          depths: maintenance[i].depths,
           description: maintenance[i].description,
           id: [maintenance[i].id],
           reporter: maintenance[i].reporter,
@@ -82,11 +83,29 @@ class Information extends Component {
           <td>{this.formatTime(dict[key].start)}</td>
           <td>{this.formatTime(dict[key].end)}</td>
           <td>{dict[key].parameters.join(", ")}</td>
+          <td>{dict[key].depths}</td>
           <td>{dict[key].description}</td>
           <td>{dict[key].reporter}</td>
         </tr>
       );
     }
+
+    var eventRows = [];
+    if (events && events.length > 0) {
+      for (var i = 0; i < events.length; i++) {
+        var event = events[i];
+        eventRows.push(
+          <tr>
+            <td>{this.formatTime(event.start)}</td>
+            <td>{this.formatTime(event.stop)}</td> 
+            <td>{event.parameter}</td>
+            <td>{event.depth ? event.depth.split(",").join(", ") : ""}</td>
+            <td>{event.comments}</td>
+          </tr>
+        );
+      }
+    }
+    
     urlFromSsh(dataset.ssh)
     return (
       <React.Fragment>
@@ -150,19 +169,29 @@ class Information extends Component {
               {dataset.citation}
             </div>
           </div>
+          <div className="readme">
+            {script.length === 1 ? (
+              <ReactMarkdown>{script[0].data}</ReactMarkdown>
+            ) : (
+              <React.Fragment>{dataset.description}</React.Fragment>
+            )}
+          </div>
           <React.Fragment>
             {maintenance.length > 0 ? (
               <div className="description">
                 <div className="desc-header">Reported maintenance periods:</div>
                 <table>
-                  <tbody>
+                  <thead>
                     <tr>
-                      <th>Start</th>
-                      <th>End</th>
+                      <th style={{ width: "150px" }}>Start</th>
+                      <th style={{ width: "150px" }}>End</th>
                       <th>Parameters</th>
+                      <th>Depths</th>
                       <th>Description</th>
                       <th>Reporter</th>
                     </tr>
+                  </thead>
+                  <tbody>
                     {rows}
                   </tbody>
                 </table>
@@ -172,13 +201,30 @@ class Information extends Component {
               ""
             )}
           </React.Fragment>
-          <div className="readme">
-            {script.length === 1 ? (
-              <ReactMarkdown>{script[0].data}</ReactMarkdown>
+          <React.Fragment>
+            {events && events.length > 0 ? (
+              <div className="description">
+                <div className="desc-header">Reported events:</div>
+                <table>
+                  <thead>
+                    <tr>
+                      <th style={{ width: "150px" }}>Start</th>
+                      <th style={{ width: "150px" }}>End</th>
+                      <th>Parameters</th>
+                      <th>Depths</th>
+                      <th>Comments</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {eventRows}
+                  </tbody>
+                </table>
+                <div className="desc-warning">INFO: Data affected by reported events were removed from original data source and then do not appear in the downloadable files.</div>
+              </div>
             ) : (
-              <React.Fragment>{dataset.description}</React.Fragment>
+              ""
             )}
-          </div>
+          </React.Fragment>
           <div className="info-contact">
             <div className="contact-header">Questions about the dataset?</div>
             <div className="contact-inner">


### PR DESCRIPTION
The events are coming from the `events.csv` file that is available in some dataset repositories. The file is accessible through a new datalakes-nodejs entry point (see PR [datalakes-nodejs#11](https://github.com/eawag-surface-waters-research/datalakes-nodejs/pull/11)).

The events are displayed in the information page, after the maintenance table:

![image](https://github.com/user-attachments/assets/3c3e7833-0ef6-4ad5-8160-7911a5382a92)

The events are optionally displayed within the line graph and the heatmap.

* In the Plot Controls paenl, a new Display Option is available: "Show Events" (default is false)

![image](https://github.com/user-attachments/assets/c12ce365-0881-4362-ba54-9f9df574c20a)

* On the line graph the background is grey when at least one event is identified on the time axis, the mouse over displays the tooltip with the event details

![image](https://github.com/user-attachments/assets/95f9e3b1-f1fe-445d-bb39-a90debda1ecc)

* On the heatmap any events associated to the data point are displayed within the tooltip (events are filtered by depths list or range) 

![image](https://github.com/user-attachments/assets/44bb2c5f-0871-4d73-b405-f9edc3de1dd6)

Note: the events can overlap themselves, the list of events is then turned into a list of distinct time intervals having one or more events associated
