### PR TITLE
feat: specify UTC time

### DIFF
--- a/src/components/reportissue/reportissue.jsx
+++ b/src/components/reportissue/reportissue.jsx
@@ -629,8 +629,8 @@ class ReportIssue extends Component {
                   <table className="table table-striped">
                     <thead>
                       <tr>
-                        <th>Start</th>
-                        <th>End</th>
+                        <th>Start (UTC)</th>
+                        <th>End (UTC)</th>
                         <th>Parameters</th>
                         <th>Depths</th>
                         <th>Description</th>

--- a/src/pages/datadetail/inner/information.jsx
+++ b/src/pages/datadetail/inner/information.jsx
@@ -189,8 +189,8 @@ class Information extends Component {
                 <table className="table table-striped">
                   <thead>
                     <tr>
-                      <th style={{ width: "150px" }}>Start</th>
-                      <th style={{ width: "150px" }}>End</th>
+                      <th style={{ width: "150px" }}>Start (UTC)</th>
+                      <th style={{ width: "150px" }}>End (UTC)</th>
                       <th>Parameters</th>
                       <th>Depths</th>
                       <th>Description</th>
@@ -215,8 +215,8 @@ class Information extends Component {
                 <table className="table table-striped">
                   <thead>
                     <tr>
-                      <th style={{ width: "150px" }}>Start</th>
-                      <th style={{ width: "150px" }}>End</th>
+                      <th style={{ width: "150px" }}>Start (UTC)</th>
+                      <th style={{ width: "150px" }}>End (UTC)</th>
                       <th>Parameters</th>
                       <th>Depths</th>
                       <th>Comments</th>


### PR DESCRIPTION
To avoid confusion with local time in report form and graphs.

<img width="347" height="320" alt="image" src="https://github.com/user-attachments/assets/192ce93e-2de3-4255-92b9-a561bb530a68" />
