### PR TITLE
feat: profiles report and merge strategy

### DIFF
--- a/src/components/reportissue/reportissue.jsx
+++ b/src/components/reportissue/reportissue.jsx
@@ -86,6 +86,14 @@ class ReportIssue extends Component {
       if (selectedData.xTime) {
         start = selectedData.bbox[0][0];
         end = selectedData.bbox[1][0];
+      } else if (selectedData.times && selectedData.times.length > 0) {
+        // ensure Date objects
+        selectedData.times = selectedData.times.map((t) =>
+          t instanceof Date ? t : new Date(t)
+        );
+        // get min/max from selected times array
+        start = new Date(Math.min(...selectedData.times));
+        end = new Date(Math.max(...selectedData.times));
       }
       if (selectedData.yLabel === "Depth") {
         sensordepths = `${formatNumber(selectedData.bbox[0][1])}-${formatNumber(

--- a/src/git/commons.js
+++ b/src/git/commons.js
@@ -80,51 +80,52 @@ export class GitServiceInterface {
   }
 
   /**
-   * Creates a new branch for a Git issue.
-   * @param {number} issue_id - The ID of the issue for which to create the branch.
+   * Creates a new branch for a GitHub issue.
+   * @param {string} branch_name - The name of the branch to create if it does not exist.
    * @returns {Promise<void>} - A promise that resolves when the branch is created.
    * @throws {Error} - Throws an error if the API request fails.
    */
-  async createGitIssueBranch(issue_id) {
+  async createGitBranch(branch_name) {
     throw new Error("Not implemented. Please use a subclass that implements this method.");
   }
 
   /**
    * Merge event into the provided events file and make a merge request for this update.
+   * @param {string} branch_name - The name of the branch from which to create the merge request.
    * @param {number} issue_id - The ID of the issue for which a branch is defined.
    * @param {Object} event - The event object containing details for the merge request creation.
    * @param {string} file_path - The path to the events file, to be created if it does not exist.
    * @returns {Promise<number>} - A promise that resolves to the merge request number.
    * @throws {Error} - Throws an error if the API request fails.
    */
-  async makeEventsMergeRequest(issue_id, event, file_path) {
+  async makeEventsMergeRequest(branch_name, issue_id, event, file_path) {
     throw new Error("Not implemented. Please use a subclass that implements this method.");
   }
 
   /**
-   * Downloads a raw file from a Git issue branch.
-   * @param {number} issue_id - The ID of the issue associated with the file.
+   * Downloads a raw file from a Git branch.
+   * @param {string} branch_name - The name of the branch associated with the file.
    * @param {string} file_path - The path to the file in the repository.
    * @returns {Promise<string>} - A promise that resolves to the raw file content.
    * @throws {Error} - Throws an error if the API request fails.
    */
-  async downloadRawFile(issue_id, file_path) {
+  async downloadRawFile(branch_name, file_path) {
     throw new Error("Not implemented. Please use a subclass that implements this method.");
   }
 
   /**
-   * Merges an event into the provided events file and updates the file in the Git issue branch.
-   * @param {number} issue_id - The ID of the issue for which a branch is defined.
+   * Merges an event into the provided events file and updates the file in the Git branch.
+   * @param {string} branch_name - The name of the branch associated with the file.
    * @param {Object} event - The event object containing details for the merge request creation.
    * @param {string} file_path - The path to the events file, to be created if it does not exist.
    * @returns {Promise<void>} - A promise that resolves when the event is merged into the file.
    * @throws {Error} - Throws an error if the API request fails.
    */
-  async mergeEvents(issue_id, event, file_path) {
+  async mergeEvents(branch_name, event, file_path) {
     if (!file_path.endsWith(".csv")) {
       throw new Error("File path must end with .csv");
     }
-    let content = await this.downloadRawFile(issue_id, file_path);
+    let content = await this.downloadRawFile(branch_name, file_path);
     const exists = content.trim() !== '';
     if (!exists) {
       // new or empty file: add csv header

--- a/src/git/github.js
+++ b/src/git/github.js
@@ -243,16 +243,27 @@ export class GithubService extends GitServiceInterface {
 
   /**
    * Creates a new branch for a GitHub issue.
-   * @param {number} issue_id - The ID of the issue to create a branch for.
+   * @param {string} branch_name - The name of the branch to create if it does not exist.
    * @returns {Promise<void>} - A promise that resolves when the branch is created.
    * @throws {Error} - Throws an error if the API request fails.
    */
-  async createGitIssueBranch(issue_id) {
+  async createGitBranch(branch_name) {
     const accessToken = this.getAccessToken();
     try {
       const project = await this.getProject();
       const defaultBranch = project.default_branch;
-      const branchName = `issue-${issue_id}`;
+
+      // if branch already exists, do nothing
+      const branchResponse = await fetch(`${this.host}/repos/${this.projectPath}/git/refs/heads/${branch_name}`, {
+        method: "GET",
+        headers: {
+          "Authorization": `Bearer ${accessToken}`,
+          "Accept": "application/vnd.github+json",
+        },
+      });
+      if (branchResponse.ok) {
+        return;
+      }
 
       // Get last sha from default branch
       const response = await fetch(`${this.host}/repos/${this.projectPath}/git/refs/heads/${defaultBranch}`, {
@@ -276,32 +287,31 @@ export class GithubService extends GitServiceInterface {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          ref: `refs/heads/${branchName}`,
+          ref: `refs/heads/${branch_name}`,
           sha: defaultBranchData.object.sha,
         }),
       });
     } catch (err) {
-      console.error("Error creating GitHub issue branch:", err);
+      console.error("Error creating GitHub branch:", err);
       throw err;
     }
   }
 
   /**
    * Merge event into the provided events file and make a merge request for this update.
+   * @param {string} branch_name - The name of the branch from which to create the merge request.
    * @param {number} issue_id - The ID of the issue for which a branch is defined.
    * @param {Object} event - The event object containing details for the merge request creation.
    * @param {string} file_path - The path to the events file, to be created if it does not exist.
    * @returns {Promise<number>} - A promise that resolves to the merge request number.
    * @throws {Error} - Throws an error if the API request fails.
    */
-  async makeEventsMergeRequest(issue_id, event, file_path) {
-    const { content } = await this.mergeEvents(issue_id, event, file_path);
+  async makeEventsMergeRequest(branch_name, issue_id, event, file_path) {
+    const { content } = await this.mergeEvents(branch_name, event, file_path);
     const accessToken = this.getAccessToken();
     try {
-      const branchName = `issue-${issue_id}`;
-      
       const treeResponse = await fetch(
-        `${this.host}/repos/${this.projectPath}/git/trees/${branchName}?recursive=1`,
+        `${this.host}/repos/${this.projectPath}/git/trees/${branch_name}?recursive=1`,
         {
           headers: {
             "Authorization": `Bearer ${accessToken}`,
@@ -323,7 +333,7 @@ export class GithubService extends GitServiceInterface {
       const updateBody = {
         message: `feat:add event for issue #${issue_id}`,
         content: window.btoa(content), // Base64 encode the content
-        branch: branchName,
+        branch: branch_name,
       };
       
       // Include SHA if file exists (required for updates)
@@ -345,9 +355,28 @@ export class GithubService extends GitServiceInterface {
         throw new Error(`GitHub API error while updating file: ${response.status} - ${JSON.stringify(errorData)}`);
       }
       
-      // Create a pull request for the changes
       const project = await this.getProject();
       const defaultBranch = project.default_branch;
+
+      // Check if there is already an open pull request for this branch
+      const prCheckResponse = await fetch(
+        `${this.host}/repos/${this.projectPath}/pulls?head=${this.projectPath.split('/')[0]}:${branch_name}&base=${defaultBranch}&state=open`,
+        {
+          headers: {
+            "Authorization": `Bearer ${accessToken}`,
+            "Accept": "application/vnd.github+json",
+          },
+        }
+      );
+      if (!prCheckResponse.ok) {
+        throw new Error(`GitHub API error while checking existing pull requests: ${prCheckResponse.status}`);
+      }
+      const existingPRs = await prCheckResponse.json();
+      if (existingPRs.length > 0) {
+        return existingPRs[0].number; // Return the existing pull request number
+      }
+
+      // Create a pull request for the changes
       const prResponse = await fetch(`${this.host}/repos/${this.projectPath}/pulls`, {
         method: "POST",
         headers: {
@@ -356,9 +385,9 @@ export class GithubService extends GitServiceInterface {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          title: `Update events for issue #${issue_id}`,
-          body: `This pull request updates the events file for issue #${issue_id}.`,
-          head: branchName,
+          title: "Update events from reported issues",
+          body: `This pull request updates the events file from reported and confirmed issues.\n\nRelates to #${issue_id}`,
+          head: branch_name,
           base: defaultBranch,
         }),
       });
@@ -376,18 +405,17 @@ export class GithubService extends GitServiceInterface {
 
   /**
    * Downloads a raw file from a GitHub issue branch.
-   * @param {number} issue_id - The ID of the issue associated with the file.
+   * @param {string} branch_name - The name of the branch associated with the file.
    * @param {string} file_path - The path to the file in the repository.
    * @returns {Promise<string>} - A promise that resolves to the raw file content.
    * @throws {Error} - Throws an error if the API request fails.
    */
 
-  async downloadRawFile(issue_id, file_path) {
+  async downloadRawFile(branch_name, file_path) {
   const accessToken = this.getAccessToken();
   try {
-    const branchName = `issue-${issue_id}`;
     const response = await fetch(
-      `https://api.github.com/repos/${this.projectPath}/contents/${file_path}?ref=${branchName}`,
+      `https://api.github.com/repos/${this.projectPath}/contents/${file_path}?ref=${branch_name}`,
       {
         method: "GET",
         headers: {

--- a/src/git/gitlab.js
+++ b/src/git/gitlab.js
@@ -299,22 +299,35 @@ export class GitlabService extends GitServiceInterface {
   }
 
   /**
-   * Creates a new branch for a GitLab issue.
-   * @param {number} issue_id - The ID of the issue for which to create the branch.
+   * Creates a new branch for a GitHub issue.
+   * @param {string} branch_name - The name of the branch to create if it does not exist.
    * @returns {Promise<void>} - A promise that resolves when the branch is created.
    * @throws {Error} - Throws an error if the API request fails.
    */
-  async createGitIssueBranch(issue_id) {
+  async createGitBranch(branch_name) {
     try {
       const accessToken = await this.refreshGitlabAccessToken();
       const projectId = encodeURIComponent(`${this.projectPath}`);
 
       const project = await this.getProject();
-      const defaultBranch = project.default_branch;
-      const branchName = `issue-${issue_id}`;
 
+      // if branch already exists, do nothing
+      const branchResponse = await fetch(`${this.host}/api/v4/projects/${projectId}/repository/branches/${branch_name}`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      if (branchResponse.ok) {
+        // Branch exists
+        return;
+      }
+
+      // Create the branch from the default branch
+      const defaultBranch = project.default_branch;
       const response = await fetch(
-        `${this.host}/api/v4/projects/${projectId}/repository/branches?branch=${branchName}&ref=${defaultBranch}`,
+        `${this.host}/api/v4/projects/${projectId}/repository/branches?branch=${branch_name}&ref=${defaultBranch}`,
         {
           method: "POST",
           headers: {
@@ -330,26 +343,26 @@ export class GitlabService extends GitServiceInterface {
         );
       }
     } catch (err) {
-      console.error("Error creating GitLab issue branch:", err);
+      console.error("Error creating GitLab branch:", err);
       throw err;
     }
   }
 
   /**
    * Merge event into the provided events file and make a merge request for this update.
+   * @param {string} branch_name - The name of the branch from which to create the merge request.
    * @param {number} issue_id - The ID of the issue for which a branch is defined.
    * @param {Object} event - The event object containing details for the merge request creation.
    * @param {string} file_path - The path to the events file, to be created if it does not exist.
    * @returns {Promise<number>} - A promise that resolves to the merge request number.
    * @throws {Error} - Throws an error if the API request fails.
    */
-  async makeEventsMergeRequest(issue_id, event, file_path) {
+  async makeEventsMergeRequest(branch_name, issue_id, event, file_path) {
     const { exists, content } = await this.mergeEvents(
-      issue_id,
+      branch_name,
       event,
       file_path
     );
-    const branchName = `issue-${issue_id}`;
     const accessToken = await this.refreshGitlabAccessToken();
     const projectId = encodeURIComponent(`${this.projectPath}`);
     // Create or update the events file in the repository
@@ -368,7 +381,7 @@ export class GitlabService extends GitServiceInterface {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          branch: branchName,
+          branch: branch_name,
           content: content,
           commit_message: `feat: add event for issue #${issue_id}`,
           encoding: "text",
@@ -380,9 +393,34 @@ export class GitlabService extends GitServiceInterface {
         `GitLab API error while creating events file: ${response.status}`
       );
     }
-    // Create a merge request for the new branch
     const project = await this.getProject();
     const defaultBranch = project.default_branch;
+
+    // Check if there is already an open pull request for this branch
+    const mrResponse = await fetch(
+      `${this.host}/api/v4/projects/${projectId}/merge_requests?state=opened&source_branch=${branch_name}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
+    if (!mrResponse.ok) {
+      throw new Error(
+        `GitLab API error while checking merge requests: ${mrResponse.status}`
+      );
+    }
+    const mergeRequests = await mrResponse.json();
+    if (mergeRequests.length > 0) {
+      console.debug(
+        "GitLab merge request already exists:",
+        mergeRequests[0]
+      );
+      return mergeRequests[0].iid; // Return the existing merge request ID
+    }
+    
+    // Create a merge request for the new branch
     const mergeRequestResponse = await fetch(
       `${this.host}/api/v4/projects/${projectId}/merge_requests`,
       {
@@ -392,10 +430,10 @@ export class GitlabService extends GitServiceInterface {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          source_branch: branchName,
+          source_branch: branch_name,
           target_branch: defaultBranch,
-          title: `Merge events for issue #${issue_id}`,
-          description: `This merge request contains events for issue #${issue_id}.`,
+          title: "Update events from reported issues",
+          description: `This merge request updates the events file from reported and confirmed issues.\n\nRelates to #${issue_id}`,
           remove_source_branch: true,
         }),
       }
@@ -412,19 +450,18 @@ export class GitlabService extends GitServiceInterface {
 
   /**
    * Downloads a raw file from a GitLab project.
-   * @param {number} issue_id - The ID of the issue associated with the file.
+   * @param {string} branch_name - The name of the branch associated with the file.
    * @param {string} file_path - The path to the file in the repository.
    * @returns {Promise<string>} - A promise that resolves to the raw file content.
    * @throws {Error} - Throws an error if the API request fails.
    */
-  async downloadRawFile(issue_id, file_path) {
+  async downloadRawFile(branch_name, file_path) {
     try {
       const accessToken = await this.refreshGitlabAccessToken();
       const projectId = encodeURIComponent(`${this.projectPath}`);
       const filePath = encodeURIComponent(file_path);
-      const branchName = `issue-${issue_id}`;
       const response = await fetch(
-        `${this.host}/api/v4/projects/${projectId}/repository/files/${filePath}/raw?ref=${branchName}`,
+        `${this.host}/api/v4/projects/${projectId}/repository/files/${filePath}/raw?ref=${branch_name}`,
         {
           method: "GET",
           headers: {

--- a/src/git/index.js
+++ b/src/git/index.js
@@ -150,9 +150,11 @@ export class GitService {
    */
   async makeEventsMergeRequest(issue_id, event) {
     if (!issue_id) return;
-    await this.service.createGitIssueBranch(issue_id);
+    const branch_name = "feat/events-report-update";
+    await this.service.createGitBranch(branch_name);
     // create a merge request for the event
     return this.service.makeEventsMergeRequest(
+      branch_name,
       issue_id,
       event,
       "notes/events.csv"

--- a/src/graphs/d3/linegraph/linegraph.jsx
+++ b/src/graphs/d3/linegraph/linegraph.jsx
@@ -242,6 +242,7 @@ class D3LineGraph extends Component {
     for (var i = 0; i < data.length; i++) {
       data[i]["lineColor"] = lcolor[i] ? lcolor[i] : "black";
       data[i]["lineWeight"] = lweight[i] ? lweight[i] : 1;
+      data[i]["time"] = legend && legend[i] && legend[i].value instanceof Date ? legend[i].value : "";
       data[i]["name"] = legend && legend[i] ? legend[i].text : "";
       data[i]["xaxis"] = legend && legend[i] ? legend[i].xaxis : "x";
       data[i]["yaxis"] = legend && legend[i] ? legend[i].yaxis : "y";

--- a/src/graphs/d3/linegraph/plotlinegraph.js
+++ b/src/graphs/d3/linegraph/plotlinegraph.js
@@ -90,7 +90,10 @@ const plotlinegraph = (div, data, options = {}) => {
     zm = zoom;
   }
   if (options.tooltip) addTooltip(data, div, xAxis, yAxis, options);
-  if (options.select) addBrush(svg, xAxis, yAxis, zmbox, zm, options);
+  if (options.select) {
+    const times = data.map(d => d.time).filter(t => t instanceof Date);
+    addBrush(svg, xAxis, yAxis, zmbox, zm, options, times);
+  }
 };
 
 const addPlottingArea = (div, svg, options) => {
@@ -1425,7 +1428,7 @@ const updatePlots = (div, g, context, data, xAxis, yAxis, options) => {
   if (options.scatter) plotScatter(context, data, xAxis, yAxis, options);
 };
 
-const addBrush = (svg, xAxis, yAxis, zoombox, zoom, options) => {
+const addBrush = (svg, xAxis, yAxis, zoombox, zoom, options, times) => {
   // Listen for keyboard events
   select("body")
     .on("keydown", (event) => {
@@ -1487,6 +1490,7 @@ const addBrush = (svg, xAxis, yAxis, zoombox, zoom, options) => {
       xUnit: options.xUnit,
       yUnit: options.yUnit,
       zUnit: null,
+      times: times,
     });
   };
 


### PR DESCRIPTION
**Profiles report**

When selected graph is a profile, select the associated date times and pre-fill the start/end time fields in report form.
Note: no mask seems to be applied from the reported issues of a profile graph 

[Screencast from 2026-01-21 16-49-37.webm](https://github.com/user-attachments/assets/4904e22b-5f14-478f-95f1-28cbc6ee34ac)

**Merge strategy**

When the "Resolved" action is selected on a reported issue:
* The branch containing the changes of the `events.csv` file has a unique name "feat/events-report-update", and is created only if it does not exists
* The corresponding merge/pull request is created only if there is none already opened

[Screencast from 2026-01-21 16-59-03.webm](https://github.com/user-attachments/assets/44a29976-fd30-466c-9e5e-a1628b9472fd)


<img width="940" height="778" alt="image" src="https://github.com/user-attachments/assets/07dbed1e-9399-47d4-b117-8c216c349307" />

Note: once merged, it is recommended to delete the "feat/events-report-update" branch to avoid conflicts when subsequent issues are resolved